### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,14 @@ jobs:
       pull-requests: write
     uses: infrastructure-blocks/check-has-semver-label-workflow/.github/workflows/workflow.yml@v2
   git-tag-from-semver-increment:
-    uses: infrastructure-blocks/git-tag-semver-from-label-workflow/.github/workflows/workflow.yml@v1
+    needs:
+      - check-has-semver-label
     permissions:
       contents: write
       pull-requests: write
+    uses: infrastructure-blocks/git-tag-from-semver-increment-workflow/.github/workflows/workflow.yml@v1
     with:
       semver-increment: ${{ needs.check-has-semver-label.outputs.matched-label }}
+      skip: ${{ needs.check-has-semver-label.outputs.matched-label == 'no version' }}
     secrets:
       github-token: ${{ secrets.PAT }}


### PR DESCRIPTION
- It was intended to use the git-tag-from-semver-increment-workflow originally,
but still referencing the legacy equivalent.
